### PR TITLE
Improves gcc versions support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -8,16 +8,16 @@ jobs:
   - job: Pomodoro
     strategy:
       matrix:
-        ubuntu_22_04_debug_gcc_9:
-          imageName: 'ubuntu-22.04'
-          generator: Unix Makefiles
-          build_configuration: 'Debug'
-          gcc_version: 9
-        ubuntu_22_04_release_gcc_9:
-          imageName: 'ubuntu-22.04'
-          generator: Unix Makefiles
-          build_configuration: 'Release'
-          gcc_version: 9
+        # ubuntu_22_04_debug_gcc_9:
+        #   imageName: 'ubuntu-22.04'
+        #   generator: Unix Makefiles
+        #   build_configuration: 'Debug'
+        #   gcc_version: 9
+        # ubuntu_22_04_release_gcc_9:
+        #   imageName: 'ubuntu-22.04'
+        #   generator: Unix Makefiles
+        #   build_configuration: 'Release'
+        #   gcc_version: 9
         ubuntu_22_04_debug_gcc_10:
           imageName: 'ubuntu-22.04'
           generator: Unix Makefiles
@@ -38,16 +38,16 @@ jobs:
           generator: Unix Makefiles
           build_configuration: 'Release'
           gcc_version: 11
-        ubuntu_20_04_debug_gcc_9:
-          imageName: 'ubuntu-20.04'
-          generator: Unix Makefiles
-          build_configuration: 'Debug'
-          gcc_version: 9
-        ubuntu_20_04_release_gcc_9:
-          imageName: 'ubuntu-20.04'
-          generator: Unix Makefiles
-          build_configuration: 'Release'
-          gcc_version: 9
+        # ubuntu_20_04_debug_gcc_9:
+        #   imageName: 'ubuntu-20.04'
+        #   generator: Unix Makefiles
+        #   build_configuration: 'Debug'
+        #   gcc_version: 9
+        # ubuntu_20_04_release_gcc_9:
+        #   imageName: 'ubuntu-20.04'
+        #   generator: Unix Makefiles
+        #   build_configuration: 'Release'
+        #   gcc_version: 9
         ubuntu_20_04_debug_gcc_10:
           imageName: 'ubuntu-20.04'
           generator: Unix Makefiles
@@ -58,26 +58,16 @@ jobs:
           generator: Unix Makefiles
           build_configuration: 'Release'
           gcc_version: 10
-        ubuntu_18_04_debug_gcc_7:
-          imageName: 'ubuntu-18.04'
-          generator: Unix Makefiles
-          build_configuration: 'Debug'
-          gcc_version: 7
-        ubuntu_18_04_release_gcc_7:
-          imageName: 'ubuntu-18.04'
-          generator: Unix Makefiles
-          build_configuration: 'Release'
-          gcc_version: 7
-        ubuntu_18_04_debug_gcc_9:
-          imageName: 'ubuntu-18.04'
-          generator: Unix Makefiles
-          build_configuration: 'Debug'
-          gcc_version: 9
-        ubuntu_18_04_release_gcc_9:
-          imageName: 'ubuntu-18.04'
-          generator: Unix Makefiles
-          build_configuration: 'Release'
-          gcc_version: 9
+        # ubuntu_18_04_debug_gcc_9:
+        #   imageName: 'ubuntu-18.04'
+        #   generator: Unix Makefiles
+        #   build_configuration: 'Debug'
+        #   gcc_version: 9
+        # ubuntu_18_04_release_gcc_9:
+        #   imageName: 'ubuntu-18.04'
+        #   generator: Unix Makefiles
+        #   build_configuration: 'Release'
+        #   gcc_version: 9
         ubuntu_18_04_debug_gcc_10:
           imageName: 'ubuntu-18.04'
           generator: Unix Makefiles

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -12,10 +12,12 @@ jobs:
           imageName: 'ubuntu-18.04'
           generator: Unix Makefiles
           build_configuration: 'Debug'
+          gcc_version: 10
         ubuntu_release:
           imageName: 'ubuntu-18.04'
           generator: Unix Makefiles
           build_configuration: 'Release'
+          gcc_version: 10
         mac_debug:
           imageName: 'macOS-10.15'
           generator: Xcode
@@ -36,8 +38,8 @@ jobs:
         vmImage: $(imageName)
     steps:
     - script: |
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 1
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 1
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$(gcc_version) 1
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$(gcc_version) 1
       displayName: 'Setup the correct version of gcc'
       condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
     - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -8,12 +8,82 @@ jobs:
   - job: Pomodoro
     strategy:
       matrix:
-        ubuntu_debug:
+        ubuntu_22_04_debug_gcc_9:
+          imageName: 'ubuntu-22.04'
+          generator: Unix Makefiles
+          build_configuration: 'Debug'
+          gcc_version: 9
+        ubuntu_22_04_release_gcc_9:
+          imageName: 'ubuntu-22.04'
+          generator: Unix Makefiles
+          build_configuration: 'Release'
+          gcc_version: 9
+        ubuntu_22_04_debug_gcc_10:
+          imageName: 'ubuntu-22.04'
+          generator: Unix Makefiles
+          build_configuration: 'Debug'
+          gcc_version: 10
+        ubuntu_22_04_release_gcc_10:
+          imageName: 'ubuntu-22.04'
+          generator: Unix Makefiles
+          build_configuration: 'Release'
+          gcc_version: 10
+        ubuntu_22_04_debug_gcc_11:
+          imageName: 'ubuntu-22.04'
+          generator: Unix Makefiles
+          build_configuration: 'Debug'
+          gcc_version: 11
+        ubuntu_22_04_release_gcc_11:
+          imageName: 'ubuntu-22.04'
+          generator: Unix Makefiles
+          build_configuration: 'Release'
+          gcc_version: 11
+        ubuntu_20_04_debug_gcc_9:
+          imageName: 'ubuntu-20.04'
+          generator: Unix Makefiles
+          build_configuration: 'Debug'
+          gcc_version: 9
+        ubuntu_20_04_release_gcc_9:
+          imageName: 'ubuntu-20.04'
+          generator: Unix Makefiles
+          build_configuration: 'Release'
+          gcc_version: 9
+        ubuntu_20_04_debug_gcc_10:
+          imageName: 'ubuntu-20.04'
+          generator: Unix Makefiles
+          build_configuration: 'Debug'
+          gcc_version: 10
+        ubuntu_20_04_release_gcc_10:
+          imageName: 'ubuntu-20.04'
+          generator: Unix Makefiles
+          build_configuration: 'Release'
+          gcc_version: 10
+        ubuntu_18_04_debug_gcc_7:
+          imageName: 'ubuntu-18.04'
+          generator: Unix Makefiles
+          build_configuration: 'Debug'
+          gcc_version: 7
+        ubuntu_18_04_release_gcc_7:
+          imageName: 'ubuntu-18.04'
+          generator: Unix Makefiles
+          build_configuration: 'Release'
+          gcc_version: 7
+        ubuntu_18_04_debug_gcc_9:
+          imageName: 'ubuntu-18.04'
+          generator: Unix Makefiles
+          build_configuration: 'Debug'
+          gcc_version: 9
+        ubuntu_18_04_release_gcc_9:
+          imageName: 'ubuntu-18.04'
+          generator: Unix Makefiles
+          build_configuration: 'Release'
+          gcc_version: 9
+        ubuntu_18_04_debug_gcc_10:
           imageName: 'ubuntu-18.04'
           generator: Unix Makefiles
           build_configuration: 'Debug'
           gcc_version: 10
-        ubuntu_release:
+        ubuntu_18_04_release_gcc_10:
           imageName: 'ubuntu-18.04'
           generator: Unix Makefiles
           build_configuration: 'Release'
@@ -38,6 +108,7 @@ jobs:
         vmImage: $(imageName)
     steps:
     - script: |
+        ls /usr/bin/gcc*
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$(gcc_version) 1
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$(gcc_version) 1
       displayName: 'Setup the correct version of gcc'

--- a/XYModem/.cmake/gcc.cmake
+++ b/XYModem/.cmake/gcc.cmake
@@ -1,0 +1,32 @@
+
+function(get_current_gcc_version output_variable)
+    find_program (
+        GCC_EXE
+        NAMES gcc gcc.exe
+        HINTS "/usr/bin"
+        DOC "Location of the gcc exxecutable"
+        NO_CACHE
+        REQUIRED
+    )
+
+    execute_process(COMMAND ${GCC_EXE} --version
+        OUTPUT_VARIABLE GCC_VERSION_RAW_OUTPUT
+    )
+
+    # Keeps only the first line of the `gcc --version` output
+    string(FIND "${GCC_VERSION_RAW_OUTPUT}" "\n" GCC_VERSION_RAW_OUTPUT_FIRST_NEW_LINE_POSITION)
+    string(SUBSTRING "${GCC_VERSION_RAW_OUTPUT}" 0 ${GCC_VERSION_RAW_OUTPUT_FIRST_NEW_LINE_POSITION} GCC_VERSION_RAW_OUTPUT)
+
+    # Keeps only the actual version of the `gcc --version` output (after the last space of the line)
+    string(FIND "${GCC_VERSION_RAW_OUTPUT}" " " GCC_VERSION_RAW_OUTPUT_LAST_SPACE_POSITION REVERSE)
+    string(SUBSTRING "${GCC_VERSION_RAW_OUTPUT}" ${GCC_VERSION_RAW_OUTPUT_LAST_SPACE_POSITION} -1 GCC_VERSION_RAW_OUTPUT)
+
+    # Removes the `.0` at the end of the version, if there is one
+    string(FIND "${GCC_VERSION_RAW_OUTPUT}" ".0" GCC_VERSION_RAW_OUTPUT_DOT_ZERO_POSITION REVERSE)
+    if(NOT ${GCC_VERSION_RAW_OUTPUT_DOT_ZERO_POSITION} EQUAL -1)
+        string(SUBSTRING "${GCC_VERSION_RAW_OUTPUT}" 0 ${GCC_VERSION_RAW_OUTPUT_DOT_ZERO_POSITION} GCC_VERSION_RAW_OUTPUT)
+    endif()
+
+    string(STRIP "${GCC_VERSION_RAW_OUTPUT}" GCC_VERSION_RAW_OUTPUT)
+    set (${output_variable} ${GCC_VERSION_RAW_OUTPUT} PARENT_SCOPE)
+endfunction()

--- a/XYModem/setupDependencies.cmake
+++ b/XYModem/setupDependencies.cmake
@@ -28,13 +28,15 @@ execute_process(
           --build=missing -s build_type=Release -s compiler.runtime=MT
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 else()
+  include(${CMAKE_CURRENT_LIST_DIR}/.cmake/gcc.cmake)
+  get_current_gcc_version(GCC_VERSION)
   execute_process(
     COMMAND ${CONAN_EXE} install . --install-folder=build -pr=${CMAKE_CURRENT_LIST_DIR}/.conan/linux_profile
-            --build=missing -s build_type=Debug
+            --build=missing -s build_type=Debug -s compiler.version=${GCC_VERSION}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
   execute_process(
     COMMAND ${CONAN_EXE} install . --install-folder=build -pr=${CMAKE_CURRENT_LIST_DIR}/.conan/linux_profile
-            --build=missing -s build_type=Release
+            --build=missing -s build_type=Release -s compiler.version=${GCC_VERSION}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 endif()
 


### PR DESCRIPTION
This PR is based on #1.

Its purpose is to make Azure Pipelines check the compilation of the project with different versions of `gcc`, on Linux.
For now, you can only compile the project if your `gcc` version matches the one used on Azure Pipelines, because of the `conan` profile. This PR is going to remove this limitation and allow us to define exactly the supported versions of `gcc`.

##List of gcc version available on Azure Pipelines
- For `ubuntu-22.04`, the gcc version available are: `7.5`, `9.4` and `10.3`
- For `ubuntu-20.04`, the gcc version available are: `9.4` and `10.3`
- For `ubuntu-22.04`, the gcc version available are: `9.4`,  `10.3` and `11.2`

Sadly, there are some issues with the versions `7.5` and `9.4` of gcc.
The first one triggers the following error when `conan` tries to install the library `crc_cpp`:
```log
crc_cpp/1.0.1: Invalid ID: crc_cpp: Unsupported compiler: gcc-7.5 Minimum C++17 constexpr features required.
```
And the second one is not supported by `conan`, for now:
```log
ERROR: Invalid setting '9.4' is not a valid 'settings.compiler.version' value.
Possible values are ['4.1', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5', '5.1', '5.2', '5.3', '5.4', '5.5', '6', '6.1', '6.2', '6.3', '6.4', '6.5', '7', '7.1', '7.2', '7.3', '7.4', '7.5', '8', '8.1', '8.2', '8.3', '8.4', '9', '9.1', '9.2', '9.3', '10', '10.1', '10.2', '10.3', '11', '11.1', '11.2', '12']
```

I have created an [issue](https://github.com/conan-io/conan/issues/11291) on `conan` repository about this last issue! :slightly_smiling_face: 
The correction has been integrated and, we are going to be able to add the support to the version `9.4` of gcc when the next release of ` conan` (the version 1.49.0) will be available (Should I create an issue about that @Riuzakiii ?).

TODO:
- [X] List the versions of `gcc` available on the different Linux systems of Azure Pipelines
- [x] Adapt Azure Pipelines to compile and build the project for each of this `gcc` version
- [x] Adapt the cmake scripts to adapt the linux profile to the current `gcc` version detected on the machine