### PR TITLE
Adds Visual Studio 2022 in the config on Azure Pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -86,11 +86,11 @@ jobs:
           imageName: 'macOS-10.15'
           generator: Xcode
           build_configuration: 'Release'
-        windows_debug:
+        windows_2019_debug:
           imageName: 'windows-2019'
           generator: Visual Studio 16 2019
           build_configuration: 'Debug'
-        windows_release:
+        windows_2019_release:
           imageName: 'windows-2019'
           generator: Visual Studio 16 2019
           build_configuration: 'Release'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -94,6 +94,14 @@ jobs:
           imageName: 'windows-2019'
           generator: Visual Studio 16 2019
           build_configuration: 'Release'
+        windows_2022_debug:
+          imageName: 'windows-2022'
+          generator: Visual Studio 17 2022
+          build_configuration: 'Debug'
+        windows_2022_release:
+          imageName: 'windows-2022'
+          generator: Visual Studio 17 2022
+          build_configuration: 'Release'
     pool:
         vmImage: $(imageName)
     steps:

--- a/XYModem/setupDependencies.cmake
+++ b/XYModem/setupDependencies.cmake
@@ -19,14 +19,22 @@ if(APPLE)
             --build=missing -s build_type=Debug
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 elseif(WIN32)
-execute_process(
-  COMMAND ${CONAN_EXE} install . --install-folder=build -pr=${CMAKE_CURRENT_LIST_DIR}/.conan/windows_profile
-          --build=missing -s build_type=Debug -s compiler.runtime=MTd
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
-execute_process(
-  COMMAND ${CONAN_EXE} install . --install-folder=build -pr=${CMAKE_CURRENT_LIST_DIR}/.conan/windows_profile
-          --build=missing -s build_type=Release -s compiler.runtime=MT
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+  if("${CMAKE_GENERATOR}" STREQUAL "Visual Studio 16 2019")
+    set(VISUAL_STUDIO_COMPILER_VERSION 16)
+  elseif("${CMAKE_GENERATOR}" STREQUAL "Visual Studio 17 2022")
+    set(VISUAL_STUDIO_COMPILER_VERSION 17)
+  else()
+    message(FATAL_ERROR "Error: Generator not supported on Windows! - CMAKE_GENERATOR: ${CMAKE_GENERATOR}")
+  endif()
+
+  execute_process(
+    COMMAND ${CONAN_EXE} install . --install-folder=build -pr=${CMAKE_CURRENT_LIST_DIR}/.conan/windows_profile
+            --build=missing -s build_type=Debug -s compiler.version=${VISUAL_STUDIO_COMPILER_VERSION} -s compiler.runtime=MTd
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
+  execute_process(
+    COMMAND ${CONAN_EXE} install . --install-folder=build -pr=${CMAKE_CURRENT_LIST_DIR}/.conan/windows_profile
+            --build=missing -s build_type=Release -s compiler.version=${VISUAL_STUDIO_COMPILER_VERSION} -s compiler.runtime=MT
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 else()
   include(${CMAKE_CURRENT_LIST_DIR}/.cmake/gcc.cmake)
   get_current_gcc_version(GCC_VERSION)


### PR DESCRIPTION
This PR is based on #7.


It adds Visual Studio 2022 in the list of configurations tested on Azure Pipelines.

Once this Pull Request integrated, Azure Pipelines will always make sure that the code compiles correctly with Visual Studio 2019 and 2022.