### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Configures Dependabot in order to help to keep the packages needed up to date.

Dependabot will check daily if the python packages defined in `requirements.txt` are up to date.
If this is not the case, it will create a Pull Request updating the package concerned.

## Interesting Resources

- [Dependabot version updates documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates)