### PR TITLE
Clang tidy integration

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -129,3 +129,44 @@ jobs:
         cd XYModem/build
         ctest -C $(build_configuration) -T Test --output-on-failure
       displayName: 'Runs the tests in $(build_configuration) configuration'
+  - job: Static_Analysis
+    strategy:
+      matrix:
+        debug:
+          imageName: 'ubuntu-22.04'
+          generator: Unix Makefiles
+          build_configuration: 'Debug'
+          gcc_version: 11
+        release:
+          imageName: 'ubuntu-22.04'
+          generator: Unix Makefiles
+          build_configuration: 'Release'
+          gcc_version: 11
+    pool:
+        vmImage: $(imageName)
+    steps:
+    - script: |
+        ls /usr/bin/gcc*
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$(gcc_version) 1
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$(gcc_version) 1
+      displayName: 'Setup the correct version of gcc'
+      condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
+    - script: |
+        sudo apt-get install clang-tidy
+        clang-tidy --version
+      displayName: 'Installs the latest version of clang-tidy'
+      condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
+    - script: |
+        pip3 install setuptools
+        pip3 install -r requirements.txt
+      displayName: 'Installs dependencies'
+    - script: |
+        cd XYModem
+        mkdir -p build
+        cd build
+        cmake .. -G "$(generator)" -DCMAKE_BUILD_TYPE=$(build_configuration) -DWITH_STATIC_ANALYSIS=ON
+      displayName: 'Generates the Solution of the Project with the static analysis tools set up'
+    - script: |
+        cd XYModem/build
+        cmake --build . --config $(build_configuration)
+      displayName: 'Compiles the solution in $(build_configuration) configuration while running the static analysis tools'

--- a/XYModem/.cmake/clangTidy.cmake
+++ b/XYModem/.cmake/clangTidy.cmake
@@ -8,5 +8,5 @@ find_program (
     REQUIRED
    )
 
-set(CLANG_TIDY_CHECKS clang-analyzer-*,performance-*)
+set(CLANG_TIDY_CHECKS clang-analyzer-*,performance-*,portability-*)
 set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE} --checks=${CLANG_TIDY_CHECKS} --warnings-as-errors=${CLANG_TIDY_CHECKS})

--- a/XYModem/.cmake/clangTidy.cmake
+++ b/XYModem/.cmake/clangTidy.cmake
@@ -8,5 +8,5 @@ find_program (
     REQUIRED
    )
 
-set(CLANG_TIDY_CHECKS clang-analyzer-*,performance-*,portability-*)
+set(CLANG_TIDY_CHECKS bugprone-*,clang-analyzer-*,performance-*,portability-*)
 set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE} --checks=${CLANG_TIDY_CHECKS} --warnings-as-errors=${CLANG_TIDY_CHECKS})

--- a/XYModem/.cmake/clangTidy.cmake
+++ b/XYModem/.cmake/clangTidy.cmake
@@ -1,0 +1,11 @@
+
+find_program (
+    CLANG_TIDY_EXE
+    NAMES clang-tidy clang-tidy.exe
+    HINTS "/usr/bin"
+    DOC "clang-tidy executable"
+    NO_CACHE
+    REQUIRED
+   )
+
+set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE})

--- a/XYModem/.cmake/clangTidy.cmake
+++ b/XYModem/.cmake/clangTidy.cmake
@@ -8,5 +8,5 @@ find_program (
     REQUIRED
    )
 
-set(CLANG_TIDY_CHECKS bugprone-*,clang-analyzer-*,performance-*,portability-*)
+set(CLANG_TIDY_CHECKS bugprone-*,clang-analyzer-*,concurrency-*,performance-*,portability-*)
 set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE} --checks=${CLANG_TIDY_CHECKS} --warnings-as-errors=${CLANG_TIDY_CHECKS})

--- a/XYModem/.cmake/clangTidy.cmake
+++ b/XYModem/.cmake/clangTidy.cmake
@@ -8,4 +8,5 @@ find_program (
     REQUIRED
    )
 
-set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE} -warnings-as-errors=clang-analyzer-*)
+set(CLANG_TIDY_CHECKS clang-analyzer-*,performance-*)
+set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE} --checks=${CLANG_TIDY_CHECKS} --warnings-as-errors=${CLANG_TIDY_CHECKS})

--- a/XYModem/.cmake/clangTidy.cmake
+++ b/XYModem/.cmake/clangTidy.cmake
@@ -8,4 +8,4 @@ find_program (
     REQUIRED
    )
 
-set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE})
+set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_EXE} -warnings-as-errors=clang-analyzer-*)

--- a/XYModem/CMakeLists.txt
+++ b/XYModem/CMakeLists.txt
@@ -6,6 +6,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_OSX_DEPLOYMENT_TARGET
     "10.12"
     CACHE STRING "Minimum OS X deployment version")
+
+set(WITH_STATIC_ANALYSIS OFF CACHE BOOL "Runs clang-tidy on this project")
+
 set(GLOBAL_APP_NAME "XYModem") 
 project(${GLOBAL_APP_NAME})
 
@@ -32,6 +35,10 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
   option(XYMODEM_BUILD_EXAMPLES "Build examples" ON)
 else()
   option(XYMODEM_BUILD_EXAMPLES "Build examples" OFF)
+endif()
+
+if(${WITH_STATIC_ANALYSIS})
+  include (${CMAKE_CURRENT_LIST_DIR}/.cmake/clangTidy.cmake)
 endif()
 
 enable_testing()

--- a/XYModem/include/XYModem/Loggers/Spdlogger.h
+++ b/XYModem/include/XYModem/Loggers/Spdlogger.h
@@ -13,10 +13,10 @@ using logType = spdlog::filename_t;
 class Spdlogger : public Logger
 {
 public:
-    Spdlogger(LogLevel logLevel = LogLevel::info, const logType pathToLogFile = {});
+    Spdlogger(LogLevel logLevel = LogLevel::info, const logType& pathToLogFile = {});
     void logMessage(std::string_view message, LogLevel level = LogLevel::info) const override;
 private:
     std::shared_ptr<spdlog::logger> logger = spdlog::default_logger ();
-    void initialiseLogger (const logType pathToLogFile, LogLevel logLevel);
+    void initialiseLogger (const logType& pathToLogFile, LogLevel logLevel);
 };
 }

--- a/XYModem/include/XYModem/Senders/YModemSender.h
+++ b/XYModem/include/XYModem/Senders/YModemSender.h
@@ -34,7 +34,7 @@ public:
      * critical), 6(off)
      * extension, and should be absolute.
      */
-    YModemSender (std::shared_ptr<DeviceHandler> deviceHandler_, std::shared_ptr<Logger> logger = std::make_shared<Logger>());
+    YModemSender (const std::shared_ptr<DeviceHandler>& deviceHandler_, const std::shared_ptr<Logger>& logger = std::make_shared<Logger>());
 
     /** Begin the YModem transmission.
      *  @param files The files to transmit

--- a/XYModem/src/FileTransferProtocol.cpp
+++ b/XYModem/src/FileTransferProtocol.cpp
@@ -61,7 +61,7 @@ void GuardConditions::dec (std::string_view guardName)
 FileTransferProtocol::FileTransferProtocol (std::shared_ptr<DeviceHandler> deviceHandler_,
                                             const unsigned int& currentState_,
                                             std::shared_ptr<Logger> logger)
-    : deviceHandler (deviceHandler_), logger(logger), currentState (currentState_)
+    : deviceHandler (std::move(deviceHandler_)), logger(std::move(logger)), currentState (currentState_)
 {
 }
 

--- a/XYModem/src/Files/DesktopFile.cpp
+++ b/XYModem/src/Files/DesktopFile.cpp
@@ -15,9 +15,9 @@ DesktopFile::DesktopFile(const ghc::filesystem::path& filePath) : filePath(fileP
 
 DesktopFile::~DesktopFile()
 {
-    if(isOpened())
+    if(DesktopFile::isOpened())
     {
-        close();
+        DesktopFile::close();
     }
 }
 

--- a/XYModem/src/Loggers/Spdlogger.cpp
+++ b/XYModem/src/Loggers/Spdlogger.cpp
@@ -4,12 +4,12 @@
 namespace xymodem
 {
 
-Spdlogger::Spdlogger(LogLevel logLevel, const logType pathToLogFile)
+Spdlogger::Spdlogger(LogLevel logLevel, const logType& pathToLogFile)
 {
     initialiseLogger(pathToLogFile, logLevel);
 }
 
-void Spdlogger::initialiseLogger (const logType pathToLogFile, const LogLevel logLevel)
+void Spdlogger::initialiseLogger (const logType& pathToLogFile, const LogLevel logLevel)
 {
     try
     {

--- a/XYModem/src/Senders/XModemSender.cpp
+++ b/XYModem/src/Senders/XModemSender.cpp
@@ -7,7 +7,7 @@ namespace xymodem
  */
 XModemSender::XModemSender (std::shared_ptr<DeviceHandler> deviceHandler_, std::shared_ptr<Logger> logger)
     : FileTransferProtocol (
-          deviceHandler_, waitingStart, logger)
+          std::move(deviceHandler_), waitingStart, std::move(logger))
 {
     guards.addGuards ({{retries, 0}, {packetsLeft, 0}});
 };

--- a/XYModem/src/Senders/YModemSender.cpp
+++ b/XYModem/src/Senders/YModemSender.cpp
@@ -4,7 +4,7 @@
 
 namespace xymodem
 {
-YModemSender::YModemSender (std::shared_ptr<DeviceHandler> deviceHandler_, std::shared_ptr<Logger> logger)
+YModemSender::YModemSender (const std::shared_ptr<DeviceHandler>& deviceHandler_, const std::shared_ptr<Logger>& logger)
     : FileTransferProtocol (
           deviceHandler_, waitingStart, logger),
       xModem (deviceHandler_, logger)


### PR DESCRIPTION
Integrates the tool [clang-tidy](https://clang.llvm.org/extra/clang-tidy/index.html) to statically analyze the code, in the CMake scripts when the attribute `WITH_STATIC_ANALYSIS` is activated.
Adds a job in Azure Pipelines to validate that no error are found by clang-tidy (or any future static analyzers) in the code.

## List of the checks added by this PR
- bugprone-*
- clang-analyzer-*
- concurrency-*
- performance-*
- portability-*

## List of checks that seems interesting to add in the future
- cppcoreguidelines-*
- misc-*
- modernize-*
- readability-*

The description of the clang-tidy check categories can be found [here](https://clang.llvm.org/extra/clang-tidy/index.html#id2),, and the detailed list of all the checks can be found [here](https://clang.llvm.org/extra/clang-tidy/checks/list.html)   

@Riuzakiii Should I create an issue or a discussion, in order to talk about which are the [list of checks](https://clang.llvm.org/extra/clang-tidy/checks/list.html) that we should add to the one clang-tidy checks by default ?