### PR TITLE
Cppcheck integration

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -207,8 +207,9 @@ jobs:
       displayName: 'Setup the correct version of gcc'
       condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
     - script: |
-        sudo apt-get install clang-tidy
+        sudo apt-get install clang-tidy cppcheck
         clang-tidy --version
+        cppcheck --version
       displayName: 'Installs the latest version of clang-tidy'
       condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
     - script: |

--- a/XYModem/.cmake/cppcheck.cmake
+++ b/XYModem/.cmake/cppcheck.cmake
@@ -8,4 +8,4 @@ find_program (
     REQUIRED
    )
 
-set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE} --std=c++${CMAKE_CXX_STANDARD} --library=/usr/lib/x86_64-linux-gnu/cppcheck/cfg/googletest.cfg --enable=warning)
+set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE} --std=c++${CMAKE_CXX_STANDARD} --library=/usr/lib/x86_64-linux-gnu/cppcheck/cfg/googletest.cfg --enable=warning,style)

--- a/XYModem/.cmake/cppcheck.cmake
+++ b/XYModem/.cmake/cppcheck.cmake
@@ -1,0 +1,11 @@
+
+find_program (
+    CPPCHECK_EXE
+    NAMES cppcheck cppcheck.exe
+    HINTS "/usr/bin"
+    DOC "cppcheck executable"
+    NO_CACHE
+    REQUIRED
+   )
+
+set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE} --std=c++${CMAKE_CXX_STANDARD} --library=/usr/lib/x86_64-linux-gnu/cppcheck/cfg/googletest.cfg --enable=warning)

--- a/XYModem/.cmake/cppcheck.cmake
+++ b/XYModem/.cmake/cppcheck.cmake
@@ -8,4 +8,4 @@ find_program (
     REQUIRED
    )
 
-set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE} --std=c++${CMAKE_CXX_STANDARD} --library=/usr/lib/x86_64-linux-gnu/cppcheck/cfg/googletest.cfg --enable=warning,style --error-exitcode=1)
+set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE} --std=c++${CMAKE_CXX_STANDARD} --library=/usr/lib/x86_64-linux-gnu/cppcheck/cfg/googletest.cfg --enable=warning,style,performance --error-exitcode=1)

--- a/XYModem/.cmake/cppcheck.cmake
+++ b/XYModem/.cmake/cppcheck.cmake
@@ -8,4 +8,4 @@ find_program (
     REQUIRED
    )
 
-set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE} --std=c++${CMAKE_CXX_STANDARD} --library=/usr/lib/x86_64-linux-gnu/cppcheck/cfg/googletest.cfg --enable=warning,style)
+set(CMAKE_CXX_CPPCHECK ${CPPCHECK_EXE} --std=c++${CMAKE_CXX_STANDARD} --library=/usr/lib/x86_64-linux-gnu/cppcheck/cfg/googletest.cfg --enable=warning,style --error-exitcode=1)

--- a/XYModem/CMakeLists.txt
+++ b/XYModem/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 
 if(${WITH_STATIC_ANALYSIS})
   include (${CMAKE_CURRENT_LIST_DIR}/.cmake/clangTidy.cmake)
+  include (${CMAKE_CURRENT_LIST_DIR}/.cmake/cppcheck.cmake)
 endif()
 
 enable_testing()

--- a/XYModem/examples/CLIParser.h
+++ b/XYModem/examples/CLIParser.h
@@ -13,7 +13,7 @@ class CLIParser
 {
 public:
     CLIParser () = default;
-    CLIParser (std::unordered_map<std::string_view, std::function<void (std::string_view)>> t_commands);
+    explicit CLIParser (std::unordered_map<std::string_view, std::function<void (std::string_view)>> t_commands);
 
     /** Parse all arguments given to the command line. When a name in the command line matches a key in the map, the corresponding 
      * function will be executed and given the value just after it (if there is one or the next value is not another command).

--- a/XYModem/include/XYModem/Devices/SerialHandler.h
+++ b/XYModem/include/XYModem/Devices/SerialHandler.h
@@ -11,7 +11,7 @@ namespace xymodem
 class SerialHandler : public DeviceHandler
 {
 public:
-    SerialHandler (serial::Serial& serialDevice_);
+    explicit SerialHandler (serial::Serial& serialDevice_);
 
     /** Write data to the device output buffer
      *  @param data the data bytes to write

--- a/XYModem/include/XYModem/Files/DesktopFile.h
+++ b/XYModem/include/XYModem/Files/DesktopFile.h
@@ -9,7 +9,7 @@ namespace xymodem
 class DesktopFile : public File
 {
 public:
-    DesktopFile (const ghc::filesystem::path& filePath);
+    explicit DesktopFile (const ghc::filesystem::path& filePath);
     ~DesktopFile();
 
     std::string getNextFileBlock(const std::intmax_t blockSizeBytes) override;

--- a/XYModem/include/XYModem/Senders/XModemSender.h
+++ b/XYModem/include/XYModem/Senders/XModemSender.h
@@ -94,10 +94,10 @@ private:
     [[maybe_unused]] static constexpr unsigned int abort = 7;
 
     static bool noConditions(GuardConditions) { return true; }
-    static bool checkNoPacketsLeft(GuardConditions t_guards) { return t_guards.get(packetsLeft) == 0; }
-    static bool checkPacketsLeft(GuardConditions t_guards) { return t_guards.get(packetsLeft) > 0; }
-    static bool checkCanRetry(GuardConditions t_guards) { return t_guards.get(retries) <= xymodem::maxRetries; }
-    static bool checkCannotRetry(GuardConditions t_guards) { return t_guards.get(retries) > xymodem::maxRetries; }
+    static bool checkNoPacketsLeft(const GuardConditions& t_guards) { return t_guards.get(packetsLeft) == 0; }
+    static bool checkPacketsLeft(const GuardConditions& t_guards) { return t_guards.get(packetsLeft) > 0; }
+    static bool checkCanRetry(const GuardConditions& t_guards) { return t_guards.get(retries) <= xymodem::maxRetries; }
+    static bool checkCannotRetry(const GuardConditions& t_guards) { return t_guards.get(retries) > xymodem::maxRetries; }
 
     // clang-format off
     [[maybe_unused]] static inline std::array<transition, 20> stateTransitions

--- a/XYModem/include/XYModem/Senders/XModemSender.h
+++ b/XYModem/include/XYModem/Senders/XModemSender.h
@@ -29,7 +29,7 @@ public:
      * @param logLevel 0(trace), 1(debug), 2(info), 3(warn), 4(error), 5(level
      * critical), 6(off)
      */
-    XModemSender (std::shared_ptr<DeviceHandler> deviceHandler_, std::shared_ptr<Logger> logger = std::make_shared<Logger>());
+    explicit XModemSender (std::shared_ptr<DeviceHandler> deviceHandler_, std::shared_ptr<Logger> logger = std::make_shared<Logger>());
 
     /** Begin the XModem transmission.
      *  @param fileAbsolutePath The absolute path to the file.

--- a/XYModem/include/XYModem/Senders/YModemSender.h
+++ b/XYModem/include/XYModem/Senders/YModemSender.h
@@ -101,8 +101,8 @@ private:
     [[maybe_unused]] static constexpr unsigned int transmissionFinished = 6;
 
     static bool noConditions(GuardConditions) { return true; }
-    static bool checkCanRetry(GuardConditions t_guards) { return t_guards.get(retries) <= xymodem::maxRetries; }
-    static bool checkCannotRetry(GuardConditions t_guards) { return t_guards.get(retries) > xymodem::maxRetries; }
+    static bool checkCanRetry(const GuardConditions& t_guards) { return t_guards.get(retries) <= xymodem::maxRetries; }
+    static bool checkCannotRetry(const GuardConditions& t_guards) { return t_guards.get(retries) > xymodem::maxRetries; }
 
     // clang-format off
     [[maybe_unused]] static inline std::array<transition, 11> stateTransitions

--- a/XYModem/include/XYModem/Senders/YModemSender.h
+++ b/XYModem/include/XYModem/Senders/YModemSender.h
@@ -35,7 +35,7 @@ public:
      * critical), 6(off)
      * extension, and should be absolute.
      */
-    YModemSender (const std::shared_ptr<DeviceHandler>& deviceHandler_, const std::shared_ptr<Logger>& logger = std::make_shared<Logger>());
+    explicit YModemSender (const std::shared_ptr<DeviceHandler>& deviceHandler_, const std::shared_ptr<Logger>& logger = std::make_shared<Logger>());
 
     /** Begin the YModem transmission.
      *  @param files The files to transmit

--- a/XYModem/include/XYModem/Tools.h
+++ b/XYModem/include/XYModem/Tools.h
@@ -18,13 +18,11 @@ namespace xymodem
             constexpr auto controlBitSize = 8;
 
             std::array<uint16_t, lookupSize> lookUpTable{ 0 };
-            uint8_t control = 0;
-            uint16_t sum = 0;
 
             for (int i = 0; i < lookupSize; ++i)
             {
-                control = static_cast<uint8_t>(i);
-                sum = 0;
+                auto control = static_cast<uint8_t>(i);
+                uint16_t sum = 0;
                 for (int j = 0; j < controlBitSize; ++j)
                 {
                     if ((control >> (7 - j) & 1U) == 1U)

--- a/XYModem/include/XYModem/XYModemConst.h
+++ b/XYModem/include/XYModem/XYModemConst.h
@@ -19,7 +19,7 @@ struct CouldNotOpenFile : public std::exception
     std::string absolutePath;
     std::string response;
 
-    explicit CouldNotOpenFile (std::string absolutePath) : absolutePath (absolutePath){};
+    explicit CouldNotOpenFile (const std::string& absolutePath) : absolutePath (absolutePath){};
 
     virtual const char* what () const throw () { return "Could not open file"; }
 };

--- a/XYModem/include/XYModem/XYModemConst.h
+++ b/XYModem/include/XYModem/XYModemConst.h
@@ -10,7 +10,7 @@ struct Timeout : public std::exception
 {
     long long timeoutSeconds = 0;
 
-    Timeout (long long timeoutSeconds) : timeoutSeconds (timeoutSeconds){};
+    explicit Timeout (long long timeoutSeconds) : timeoutSeconds (timeoutSeconds){};
 
     virtual const char* what () const throw () { return "Timeout"; }
 };
@@ -19,7 +19,7 @@ struct CouldNotOpenFile : public std::exception
     std::string absolutePath;
     std::string response;
 
-    CouldNotOpenFile (std::string absolutePath) : absolutePath (absolutePath){};
+    explicit CouldNotOpenFile (std::string absolutePath) : absolutePath (absolutePath){};
 
     virtual const char* what () const throw () { return "Could not open file"; }
 };

--- a/XYModem/src/FileTransferProtocol.cpp
+++ b/XYModem/src/FileTransferProtocol.cpp
@@ -35,7 +35,7 @@ void GuardConditions::addGuards (
 
 void GuardConditions::clear ()
 {
-    for (auto& [guard, value] : guardConditions)
+    for ([[maybe_unused]] auto& [guard, value] : guardConditions)
     {
         value = 0;
     }

--- a/XYModem/src/Senders/XModemSender.hpp
+++ b/XYModem/src/Senders/XModemSender.hpp
@@ -229,7 +229,6 @@ void XModemSender<payloadSize>::transmit (const std::shared_ptr<File>& file_,
                 logger->warn ("Timeout ... Transmission aborted");
                 throw XYModemExceptions::Timeout (
                     xymodem::timeout.count ());
-                break;
             }
         }
         else

--- a/XYModem/src/Senders/XModemSender.hpp
+++ b/XYModem/src/Senders/XModemSender.hpp
@@ -196,7 +196,6 @@ void XModemSender<payloadSize>::transmit (const std::shared_ptr<File>& file_,
     deviceHandler->flushAllInputBuffers ();
 
     logger->info ("Beginning transmission");
-    auto timerStart = std::chrono::steady_clock::now ();
     while (!isTransmissionFinished)
     {
         if (!yieldCallback ())
@@ -217,9 +216,6 @@ void XModemSender<payloadSize>::transmit (const std::shared_ptr<File>& file_,
                                              XModemSender::stateTransitions);
                 logger->debug ("Current state " + std::to_string(currentState));
                 executeState (currentState, logHex);
-
-                timerStart =
-                    std::chrono::steady_clock::now (); // reset the timeout
             }
             else
             {

--- a/XYModem/src/Senders/XModemSender.hpp
+++ b/XYModem/src/Senders/XModemSender.hpp
@@ -31,10 +31,7 @@ std::array<uint8_t, payloadSize + xymodem::totalExtraSize> XModemSender<payloadS
     std::array<uint8_t, payloadSize + xymodem::totalExtraSize> packet = { 0x00 };
     std::array<uint8_t, payloadSize> data = { 0x00 };
     // packets except header and last packet are filled with 0xFF
-    for (auto& byte : data)
-    {
-        byte = 0xFF;
-    }
+    std::fill(std::begin(data), std::end(data), uint8_t{0xFF});
 
     // Making header (SOH/STX, packetnum(0-255), 255-packetnum)
     const std::array<uint8_t, xymodem::packetHeaderSize> header = {


### PR DESCRIPTION
Adds the static analyzer [cppcheck](https://cppcheck.sourceforge.io/) to the tools used to analyze the C++ code (with clang-tidy).

This first Pull Request integrates cppcheck in the build system, and in the static analyzer job on Azure Pipelines.
It only activates the checks categorized as "warning", "style" and "performance" by cppcheck. The other kind of checks will be added in future Pull Request.

The code base did not trigger "warning" or "performance" from cppcheck, only "style" issues, so they have been corrected in order to make the tests pass successfully.