### PR TITLE
Include what you use integration

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -207,9 +207,10 @@ jobs:
       displayName: 'Setup the correct version of gcc'
       condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
     - script: |
-        sudo apt-get install clang-tidy cppcheck
+        sudo apt-get install clang-tidy cppcheck iwyu
         clang-tidy --version
         cppcheck --version
+        iwyu --version
       displayName: 'Installs the latest version of clang-tidy'
       condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Linux'))
     - script: |

--- a/XYModem/.cmake/includeWhatYouUse.cmake
+++ b/XYModem/.cmake/includeWhatYouUse.cmake
@@ -1,0 +1,11 @@
+
+find_program (
+    INCLUDE_WHAT_YOU_USE_EXE
+    NAMES iwyu iwyu.exe
+    HINTS "/usr/bin"
+    DOC "include-what-you-use executable"
+    NO_CACHE
+    REQUIRED
+   )
+
+set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${INCLUDE_WHAT_YOU_USE_EXE})

--- a/XYModem/CMakeLists.txt
+++ b/XYModem/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 if(${WITH_STATIC_ANALYSIS})
   include (${CMAKE_CURRENT_LIST_DIR}/.cmake/clangTidy.cmake)
   include (${CMAKE_CURRENT_LIST_DIR}/.cmake/cppcheck.cmake)
+  include (${CMAKE_CURRENT_LIST_DIR}/.cmake/includeWhatYouUse.cmake)
 endif()
 add_subdirectory(src)
 


### PR DESCRIPTION
Based on #35.

Adds the static analyzer [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) to the tools used to analyze the C++ code (with clang-tidy and cppcheck).

The code in the repository doesn't trigger any warnings from `include-what-you-use` for now, but this integration will make sure that no warning will be generated in future modifications.