### PR TITLE
Cpplint integration

### DIFF
--- a/XYModem/.cmake/cpplint.cmake
+++ b/XYModem/.cmake/cpplint.cmake
@@ -1,0 +1,11 @@
+
+find_program (
+    CPPLINT_EXE
+    NAMES cpplint cpplint.exe
+    HINTS "/usr/bin"
+    DOC "cpplint executable"
+    NO_CACHE
+    REQUIRED
+   )
+
+set(CMAKE_CXX_CPPLINT ${CPPLINT_EXE})

--- a/XYModem/CMakeLists.txt
+++ b/XYModem/CMakeLists.txt
@@ -92,6 +92,7 @@ if(${WITH_STATIC_ANALYSIS})
   include(${CMAKE_CURRENT_LIST_DIR}/.cmake/clangTidy.cmake)
   include(${CMAKE_CURRENT_LIST_DIR}/.cmake/cppcheck.cmake)
   include(${CMAKE_CURRENT_LIST_DIR}/.cmake/includeWhatYouUse.cmake)
+  include(${CMAKE_CURRENT_LIST_DIR}/.cmake/cpplint.cmake)
 endif()
 add_subdirectory(src)
 

--- a/XYModem/examples/CLIParser.cpp
+++ b/XYModem/examples/CLIParser.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include "CLIParser.h"
 
 using CommandType = std::unordered_map<std::string_view, std::function<void (std::string_view)>>;

--- a/XYModem/examples/example_xmodem.cpp
+++ b/XYModem/examples/example_xmodem.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 /*
  * Usage : ./xmodem.exe -f "filepath" -port COM1
  * -h : get help

--- a/XYModem/examples/example_ymodem.cpp
+++ b/XYModem/examples/example_ymodem.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 /*
  * Usage : ./ymodem.exe -f "filepath" -port COM1
  * -h : get help

--- a/XYModem/src/Backends/Devices/SerialHandler.cpp
+++ b/XYModem/src/Backends/Devices/SerialHandler.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include "Devices/SerialHandler.h"
 #ifdef _WIN32
 #include <chrono>

--- a/XYModem/src/Backends/Files/DesktopFile.cpp
+++ b/XYModem/src/Backends/Files/DesktopFile.cpp
@@ -1,4 +1,6 @@
-﻿#include "Files/DesktopFile.h"
+﻿// Copyright 2022 Riuzakiii
+
+#include "Files/DesktopFile.h"
 #include <cassert>
 
 namespace xymodem

--- a/XYModem/src/Backends/Loggers/Spdlogger.cpp
+++ b/XYModem/src/Backends/Loggers/Spdlogger.cpp
@@ -1,4 +1,6 @@
-﻿#include "Loggers/Spdlogger.h"
+﻿// Copyright 2022 Riuzakiii
+
+#include "Loggers/Spdlogger.h"
 #include <cassert>
 
 namespace xymodem

--- a/XYModem/src/XYModem/Devices/DeviceHandler.cpp
+++ b/XYModem/src/XYModem/Devices/DeviceHandler.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include "Devices/DeviceHandler.h"
 #include <iomanip>
 #include <ios>

--- a/XYModem/src/XYModem/FileTransferProtocol.cpp
+++ b/XYModem/src/XYModem/FileTransferProtocol.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include "FileTransferProtocol.h"
 #include <cassert>
 

--- a/XYModem/src/XYModem/Files/File.cpp
+++ b/XYModem/src/XYModem/Files/File.cpp
@@ -1,4 +1,6 @@
-﻿#include "Files/File.h"
+﻿// Copyright 2022 Riuzakiii
+
+#include "Files/File.h"
 
 namespace xymodem
 {

--- a/XYModem/src/XYModem/Loggers/Logger.cpp
+++ b/XYModem/src/XYModem/Loggers/Logger.cpp
@@ -1,4 +1,6 @@
-﻿#include "Loggers/Logger.h"
+﻿// Copyright 2022 Riuzakiii
+
+#include "Loggers/Logger.h"
 
 namespace xymodem
 {

--- a/XYModem/src/XYModem/Senders/YModemSender.hpp
+++ b/XYModem/src/XYModem/Senders/YModemSender.hpp
@@ -20,7 +20,7 @@ YModemSender<payloadSize>::makeHeaderPacket (const std::string& fileName_, const
     assert (lastModificationDate_ >= 0);
     std::array<uint8_t, payloadSize + xymodem::totalExtraSize> packet = {0x00};
     std::array<uint8_t, payloadSize> data = {0x00};
-    auto dataIterator = data.begin(); // NOLINT(readability-qualified-auto)
+    auto dataIterator = data.begin();
 
     // Making header
     static uint8_t payloadType = 0;

--- a/XYModem/tests/TestTools.cpp
+++ b/XYModem/tests/TestTools.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include "Tools.h"
 // clang-format off
 #include "crc_cpp.h"

--- a/XYModem/tests/TestTools.cpp
+++ b/XYModem/tests/TestTools.cpp
@@ -79,7 +79,7 @@ TEST (TestTools, TestDecimalToOctal)
     std::uniform_int_distribution<unsigned int> distrib (0, (std::numeric_limits<unsigned int>::max)());
     auto randomDecimalInt = distrib (gen);
     auto octal = xymodem::tools::decimalToOctal (randomDecimalInt);
-    char* begin = octal.data();       // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    char* end = begin + octal.size(); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    char* begin = octal.data();
+    char* end = std::next (begin, static_cast<long> (octal.size()));
     EXPECT_EQ (randomDecimalInt, std::strtoul (begin, &end, 8));
 }

--- a/XYModem/tests/TestXModemTransitions.cpp
+++ b/XYModem/tests/TestXModemTransitions.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include "Devices/SerialHandler.h"
 #include "XYModem.h"
 #include "serial/serial.h"

--- a/XYModem/tests/TestXYModemHelper.cpp
+++ b/XYModem/tests/TestXYModemHelper.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include "Devices/SerialHandler.h"
 #include "Tools.h"
 #include "XYModem.h"

--- a/XYModem/tests/TestYModemTransitions.cpp
+++ b/XYModem/tests/TestYModemTransitions.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include "Devices/SerialHandler.h"
 #include "XYModem.h"
 #include "serial/serial.h"

--- a/XYModem/tests/TestYModemTransitions.cpp
+++ b/XYModem/tests/TestYModemTransitions.cpp
@@ -8,7 +8,7 @@ namespace xymodem
 class YModemTest : public testing::Test
 {
 public:
-    YModemTest() : deviceHandler (std::make_shared<SerialHandler> (serialDevice)), yModem (deviceHandler){};
+    YModemTest() : deviceHandler (std::make_shared<SerialHandler> (serialDevice)), yModem (deviceHandler) {}
 
     [[nodiscard]] auto getYModem() const -> const auto& { return yModem; }
     [[nodiscard]] auto getYModem() -> auto& { return yModem; }

--- a/XYModem/tests/main.cpp
+++ b/XYModem/tests/main.cpp
@@ -1,3 +1,5 @@
+// Copyright 2022 Riuzakiii
+
 #include <gtest/gtest.h>
 
 int main (int argc, char** argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gcovr==5.0
 wheel==0.37.1
 clang-format==14.0.6
 cmake-format==0.6.13
+cpplint==1.6.0


### PR DESCRIPTION
Based on #38.

Integrates the static analyzer tool [cpplint](https://github.com/cpplint/cpplint) to the tools used to analyze the C++ code (with clang-tidy, cppcheck and include-what-you-use).

With this tool, the goal is to make the code follow a standard and make it more readable.

@Riuzakiii There is the last element mentioned by `cpplint` for the files of the project about copyright message:
```
No copyright message found.  You should have a line: "Copyright [year] <Copyright Owner>"  [legal/copyright] [5]
```
Is it OK for you if I add the comment `// Copyright 2022 Riuzakiii` on top of the cpp files to make the code comply to all the `cpplint` messages ?

