### PR TITLE
Attempt at fixing modification date

### DIFF
--- a/XYModem/include/XYModem/Tools.h
+++ b/XYModem/include/XYModem/Tools.h
@@ -100,5 +100,18 @@ namespace tools
         }
         --numPacket;
     }
+
+    template <typename Integer>
+    std::string decimalToOctal (Integer decimalInt)
+    {
+        std::string result;
+        while (decimalInt != 0 || result.empty())
+        {
+            auto remainder = decimalInt % 8;
+            decimalInt /= 8;
+            result.insert (result.begin(), '0' + static_cast<char> (remainder));
+        }
+        return result;
+    }
 } // namespace tools
 } // namespace xymodem

--- a/XYModem/src/Backends/Files/DesktopFile.cpp
+++ b/XYModem/src/Backends/Files/DesktopFile.cpp
@@ -7,7 +7,7 @@ DesktopFile::DesktopFile (const ghc::filesystem::path& filePath) : filePath (fil
 {
     filename = filePath.filename().string();
     filesize = static_cast<std::intmax_t> (ghc::filesystem::file_size (filePath));
-    lastModificationDate = ghc::filesystem::last_write_time (filePath).time_since_epoch().count();
+    lastModificationDate = std::chrono::duration_cast<std::chrono::seconds> (ghc::filesystem::last_write_time (filePath).time_since_epoch()).count();
 }
 
 DesktopFile::~DesktopFile()

--- a/XYModem/src/XYModem/Senders/YModemSender.hpp
+++ b/XYModem/src/XYModem/Senders/YModemSender.hpp
@@ -44,8 +44,11 @@ YModemSender<payloadSize>::makeHeaderPacket (const std::string& fileName_, const
     std::copy (fileSizeStr.begin(), fileSizeStr.end(), dataIterator);
     dataIterator += fileSizeStr.size();
     *(dataIterator++) = xymodem::headerFieldsSep;
-    const auto lastModificationDateStr = std::to_string (lastModificationDate_);
+    const auto lastModificationDateStr = tools::decimalToOctal (lastModificationDate_);
     std::copy (lastModificationDateStr.begin(), lastModificationDateStr.end(), dataIterator);
+
+    // The YModem protocole specifies that the header should not have a CRC. TeraTerm requires a CRC at the end of the header,
+    // so unfortunately CRC is needed
 
     // Computing CRC
     const auto crc = xymodem::tools::compute_crc16xmodem (data);

--- a/XYModem/tests/TestTools.cpp
+++ b/XYModem/tests/TestTools.cpp
@@ -8,6 +8,8 @@
 #include "gtest/gtest.h"
 #include <algorithm>
 #include <array>
+#include <cstdlib>
+#include <limits>
 #include <random>
 
 TEST (TestTools, TestDispByteArray)
@@ -66,4 +68,16 @@ TEST (TestTools, TestCRC16)
 
         EXPECT_EQ (xymodem::tools::compute_crc16xmodem (data), crc.final());
     }
+}
+
+TEST (TestTools, TestDecimalToOctal)
+{
+    std::random_device randomDevice;
+    std::mt19937 gen (randomDevice());
+    std::uniform_int_distribution<unsigned int> distrib (0, (std::numeric_limits<unsigned int>::max)());
+    auto randomDecimalInt = distrib (gen);
+    auto octal = xymodem::tools::decimalToOctal (randomDecimalInt);
+    char* begin = octal.data();       // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    char* end = begin + octal.size(); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    EXPECT_EQ (randomDecimalInt, std::strtoul (begin, &end, 8));
 }


### PR DESCRIPTION
close https://github.com/Riuzakiii/XYModem/issues/3

The issue was not an issue actually : the sender needs the file size but the receiver should not base itself on this to determinate the file size (only write blocks after blocks). The only thing to fix is the last modification date optional field.